### PR TITLE
Show "Settings" link only for enabled plugins

### DIFF
--- a/web/themes/bootstrap/views/admin/settings.php
+++ b/web/themes/bootstrap/views/admin/settings.php
@@ -47,7 +47,7 @@
 					'imageUrl'=>false,
 					'label'=>Yii::t('sourcebans', 'views.admin.settings.plugins.grid.settings'),
 					'url'=>'Yii::app()->createUrl("plugins/settings", array("id" => $data->id))',
-					'visible'=>'$data->status && $data->getViewFile("settings")',
+					'visible'=>'$data->status == SBPlugin::STATUS_ENABLED && $data->getViewFile("settings")',
 				),
 			),
 			'template'=>'{settings}',


### PR DESCRIPTION
I think it will be good to hide settings link for disabled plugins, because some plugins "runSettings" action can't work properly without overrides (from this plugin) for onBeginRequest 
